### PR TITLE
Czech translation update

### DIFF
--- a/ThinkpadAssistant/cs.lproj/Localizable.strings
+++ b/ThinkpadAssistant/cs.lproj/Localizable.strings
@@ -17,4 +17,10 @@
 "Wi-Fi\nenabled" = "Wi-Fi\nzapnuta";
 
 /* No comment provided by engineer. */
+"Bluetooth\ndisabled" = "Bluetooth\nvypnuto";
+
+/* No comment provided by engineer. */
+"Bluetooth\nenabled" = "Bluetooth\nzapnuto";
+
+/* No comment provided by engineer. */
 "Version" = "Verze";


### PR DESCRIPTION
Hello, 

I updated Czech translation.

Fun fact: I was thinking about the most appropriate form of the word On / Off. Microsoft uses "zapnuto" which means on in "It Bluetooth" form. Apple uses "zapnutý" which means on in "He Bluetooth" form. After a short thought, I chose "zapnuto" because it just sounds better and more meaningful. According to the Czech language institute dictionary, both forms are correct. 

![Snímek obrazovky 2020-05-26 v 10 52 57](https://user-images.githubusercontent.com/20557318/83003206-48d31200-a00e-11ea-9026-a714120b54c2.png)
![Snímek obrazovky 2020-05-26 v 10 53 55](https://user-images.githubusercontent.com/20557318/83003211-4a9cd580-a00e-11ea-9e86-663c93d1966f.png)
