### PR TITLE
Use DMG instead of ZIP and add main.yml [enhancement]

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,19 @@
+name: Build and Test Thinkpad Assistant
+
+on: 
+  - pull_request
+
+jobs:
+  CI:
+
+    runs-on: macos-10.15
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Prepare Env
+      run: |
+        pod install
+
+    - name: Debug Build
+      run: xcodebuild -workspace ThinkpadAssistant.xcworkspace -scheme ThinkpadAssistant -destination "platform=macOS" -archivePath target.xcarchive -configuration Debug CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO | xcpretty && exit ${PIPESTATUS[0]}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,26 +13,45 @@ jobs:
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
     - uses: actions/checkout@v2
 
-    # Build Release and Archive
-    - name: Archive
-      run: xcodebuild 
-        -workspace ThinkpadAssistant.xcworkspace 
-        -scheme ThinkpadAssistant 
+    # Download necessary software and install CocoaPods
+    - name: Prepare Env
+      run: |
+        brew install graphicsmagick imagemagick
+        npm install --global create-dmg
+        pod install
+        
+    # Build Thinkpad Assistant
+    - name: Build
+      run: xcodebuild
+        -workspace ThinkpadAssistant.xcworkspace
+        -scheme ThinkpadAssistant
         -destination "platform=macOS"
-        -archivePath target.xcarchive
-        -configuration Release clean archive 
+        -configuration Release
+        -derivedDataPath build
+        CODE_SIGN_IDENTITY=""
+        CODE_SIGNING_REQUIRED=NO
       
-    - name: Export
-      run: xcodebuild 
-        -exportArchive 
-        -exportOptionsPlist ThinkpadAssistant/Info.plist 
-        -archivePath target.xcarchive 
-        -exportPath .
-         
-    - name: Compress
-      run: zip -r ThinkpadAssistant.zip ThinkpadAssistant.app
-      
-    - name: Create Release
+    # Uncomment when code signing is finished
+    #- name: Export
+    #  run: xcodebuild
+    #    -exportArchive
+    #    -exportOptionsPlist ThinkpadAssistant/Info.plist
+    #    -archivePath target.xcarchive
+    #    -exportPath . 
+
+    # Create Apple Disk Image
+    - name: Create DMG
+      run: |
+        XCBUILD_PATH="build/Build/Products/Release"
+        #cp LICENSE $XCBUILD_PATH/license.txt
+        cd $XCBUILD_PATH
+        create-dmg ThinkpadAssistant.app || true
+        mv *.dmg ThinkpadAssistant.dmg
+        cd -
+        mkdir Assets
+        cp -R ${XCBUILD_PATH}/*.dmg Assets
+        
+    - name: Create release
       id: create_release
       uses: actions/create-release@v1
       env:
@@ -42,13 +61,14 @@ jobs:
         release_name: Release ${{ github.ref }}
         draft: false
         prerelease: false
-    - name: Upload Release Asset
+        
+    - name: Upload release assets
       id: upload-release-asset 
       uses: actions/upload-release-asset@v1
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
-        upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps 
-        asset_path: ./ThinkpadAssistant.zip
-        asset_name: ThinkpadAssistant-${GITHUB_REF##*/}.zip
-        asset_content_type: application/zip
+        upload_url: ${{ steps.create_release.outputs.upload_url }} 
+        asset_path: Assets/ThinkpadAssistant.dmg
+        asset_name: ThinkpadAssistant.dmg
+        asset_content_type: application/x-apple-diskimage

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,7 +51,7 @@ jobs:
         mkdir Assets
         cp -R ${XCBUILD_PATH}/*.dmg Assets
         
-    - name: Create release
+    - name: Create Release
       id: create_release
       uses: actions/create-release@v1
       env:
@@ -62,7 +62,7 @@ jobs:
         draft: false
         prerelease: false
         
-    - name: Upload release assets
+    - name: Upload Release Assets
       id: upload-release-asset 
       uses: actions/upload-release-asset@v1
       env:


### PR DESCRIPTION
Hello,
I would suggest that we use DMG instead of ZIP. DMGs are considered a standard for app distribution outside of an App Store. Their file size is similar to ZIP and you get that fancy UI for app installation. I would also suggest adding a FOSS license to the project to fix [problems that arise from not having any](https://choosealicense.com/no-permission/). Main.yml was added for pull requests testing. There is currently CODE_SIGNING_REQUIRED=NO, someone with a developer certificate must take care of this ( Some good examples [1](https://www.jviotti.com/2016/03/16/how-to-code-sign-os-x-electron-apps-in-travis-ci.html), [2](https://github.com/Apple-Actions/import-codesign-certs), [App and DMG notarization](https://github.com/bjesuiter/macos-file-summoner/blob/master/.github/workflows/go.yml) ). 

ThinkpadAssistant could be distributed as both. That would be waste of space in my opinion though.

![Snímek obrazovky 2020-08-01 v 19 21 26](https://user-images.githubusercontent.com/20557318/89106993-0ecb2580-d42e-11ea-9162-a137dc465a1c.png)
